### PR TITLE
Improve linting and formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,39 +2,48 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   test:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '20'
-        cache: 'yarn'
-    
-    - name: Install dependencies
-      run: yarn install --frozen-lockfile
-    
-    - name: Install Playwright browsers
-      run: npx playwright install chromium
-    
-    - name: Run tests
-      run: yarn test
-    
-    - name: Build
-      run: yarn build
-    
-    - name: Upload test results
-      uses: actions/upload-artifact@v4
-      if: always()
-      with:
-        name: playwright-report
-        path: playwright-report/
-        retention-days: 30 
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "yarn"
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Check formatting
+        run: yarn format:check
+
+      - name: Lint
+        run: yarn lint:check
+
+      - name: Type check
+        run: yarn typecheck
+
+      - name: Install Playwright browsers
+        run: npx playwright install chromium
+
+      - name: Run tests
+        run: yarn test
+
+      - name: Build
+        run: yarn build
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30

--- a/.lighthouserc.js
+++ b/.lighthouserc.js
@@ -1,11 +1,11 @@
 module.exports = {
   ci: {
     collect: {
-      startServerCommand: 'yarn build && yarn preview',
-      url: ['http://localhost:3000'],
+      startServerCommand: "yarn build && yarn preview",
+      url: ["http://localhost:3000"],
       numberOfRuns: 3,
       settings: {
-        onlyCategories: ['performance', 'accessibility', 'best-practices', 'seo'],
+        onlyCategories: ["performance", "accessibility", "best-practices", "seo"],
         throttling: {
           rttMs: 150,
           throughputKbps: 1638.4,
@@ -15,11 +15,11 @@ module.exports = {
     },
     assert: {
       assertions: {
-        'categories:performance': ['error', { minScore: 0.9 }],
-        'categories:accessibility': ['error', { minScore: 0.9 }],
-        'categories:best-practices': ['error', { minScore: 0.9 }],
-        'categories:seo': ['error', { minScore: 0.9 }],
+        "categories:performance": ["error", {minScore: 0.9}],
+        "categories:accessibility": ["error", {minScore: 0.9}],
+        "categories:best-practices": ["error", {minScore: 0.9}],
+        "categories:seo": ["error", {minScore: 0.9}],
       },
     },
   },
-}; 
+}

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,5 @@
 # Ignore artifacts:
 build
 dist
-public
+/public
 node_modules

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Source code for [iris.to](https://iris.to)
 
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/irislib/iris-client)
 
-
 ## Development
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -20,13 +20,16 @@
     "build": "tsx ./scripts/updateSocialGraph.ts && tsc && vite build --mode production",
     "build:dev": "tsx ./scripts/updateSocialGraph.ts && tsc && vite build --mode development",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --fix",
+    "lint:check": "eslint . --ext ts,tsx --report-unused-disable-directives",
     "preview": "vite preview",
     "pretest": "npx playwright install --with-deps chromium",
     "test": "playwright test --reporter=list",
     "test:ui": "playwright test --ui",
     "test:performance": "playwright test feed-performance.spec.ts --reporter=list",
     "performance:baseline": "tsx ./scripts/performance-baseline.ts",
-    "format": "prettier --write \"**/*.+(js|jsx|tsx|json|yml|yaml|css|md)\""
+    "format": "prettier --write \"**/*.+(js|jsx|tsx|json|yml|yaml|css|md)\"",
+    "format:check": "prettier --check \"**/*.+(js|jsx|tsx|json|yml|yaml|css|md)\"",
+    "typecheck": "tsc --noEmit"
   },
   "build": {
     "extends": null,

--- a/scripts/performance-baseline.ts
+++ b/scripts/performance-baseline.ts
@@ -40,7 +40,28 @@ async function captureBaseline() {
   }
 }
 
-function extractMetric(results: any, metricName: string): number {
+interface TestResult {
+  title?: string
+  results?: Array<{duration: number}>
+}
+
+interface SuiteResult {
+  tests?: TestResult[]
+}
+
+interface PlaywrightResults {
+  suites?: SuiteResult[]
+}
+
+function extractMetric(results: unknown, metricName: string): number {
+  const suites = (results as PlaywrightResults)?.suites ?? []
+  for (const suite of suites) {
+    for (const test of suite.tests ?? []) {
+      if (test.title === metricName) {
+        return test.results?.[0]?.duration ?? 0
+      }
+    }
+  }
   return 0
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -6,7 +6,8 @@ html {
   font-size: 15px;
 }
 
-.btn, .input {
+.btn,
+.input {
   @apply rounded-full;
 }
 
@@ -78,12 +79,12 @@ iframe {
 
 /* src/shared/styles/scrollbar.css */
 .scrollbar-hide {
-  -ms-overflow-style: none;  /* Internet Explorer 10+ */
-  scrollbar-width: none;  /* Firefox */
+  -ms-overflow-style: none; /* Internet Explorer 10+ */
+  scrollbar-width: none; /* Firefox */
 }
 
 .scrollbar-hide::-webkit-scrollbar {
-  display: none;  /* Safari and Chrome */
+  display: none; /* Safari and Chrome */
 }
 
 /* modals */

--- a/src/pages/chats/public/PopularChannelItem.tsx
+++ b/src/pages/chats/public/PopularChannelItem.tsx
@@ -1,8 +1,8 @@
-import {useNavigate} from "react-router"
 import {fetchChannelMetadata, ChannelMetadata} from "../utils/channelMetadata"
-import {useEffect, useState} from "react"
-import ProxyImg from "@/shared/components/ProxyImg"
 import MinidenticonImg from "@/shared/components/user/MinidenticonImg"
+import ProxyImg from "@/shared/components/ProxyImg"
+import {useEffect, useState} from "react"
+import {useNavigate} from "react-router"
 
 type PopularChannelItemProps = {
   channelId: string
@@ -46,9 +46,11 @@ const PopularChannelItem = ({channelId, authorCount}: PopularChannelItemProps) =
               <MinidenticonImg username={channelId} className="w-10 h-10 rounded-full" />
             )}
             <div>
-              <h3 className="font-semibold">{metadata?.name || `Channel ${channelId.slice(0, 8)}...`}</h3>
+              <h3 className="font-semibold">
+                {metadata?.name || `Channel ${channelId.slice(0, 8)}...`}
+              </h3>
               <p className="text-xs text-base-content/70">
-                {authorCount} {authorCount === 1 ? 'person' : 'people'} you follow
+                {authorCount} {authorCount === 1 ? "person" : "people"} you follow
               </p>
             </div>
           </div>

--- a/src/pages/chats/public/PopularChannels.tsx
+++ b/src/pages/chats/public/PopularChannels.tsx
@@ -1,8 +1,8 @@
-import {useState, useEffect} from "react"
-import {ndk} from "@/utils/ndk"
-import socialGraph from "@/utils/socialGraph"
 import PopularChannelItem from "./PopularChannelItem"
 import {CHANNEL_MESSAGE} from "../utils/constants"
+import socialGraph from "@/utils/socialGraph"
+import {useState, useEffect} from "react"
+import {ndk} from "@/utils/ndk"
 
 type PopularChannel = {
   id: string
@@ -51,17 +51,17 @@ const PopularChannels = ({publicKey}: PopularChannelsProps) => {
         console.log("Channel messages count:", channelMessages.size)
 
         // Process messages to identify channels and count unique authors
-        const channelMap = new Map<string, { authors: Set<string> }>()
+        const channelMap = new Map<string, {authors: Set<string>}>()
 
         for (const event of Array.from(channelMessages)) {
           // Extract channel ID from the 'e' tag
-          const channelIdTag = event.tags.find(tag => tag[0] === 'e')
+          const channelIdTag = event.tags.find((tag) => tag[0] === "e")
           if (!channelIdTag) continue
 
           const channelId = channelIdTag[1]
 
           if (!channelMap.has(channelId)) {
-            channelMap.set(channelId, { authors: new Set() })
+            channelMap.set(channelId, {authors: new Set()})
           }
 
           const channelData = channelMap.get(channelId)!
@@ -114,11 +114,7 @@ const PopularChannels = ({publicKey}: PopularChannelsProps) => {
         </div>
       )}
 
-      {error && (
-        <div className="text-center py-8 text-error">
-          {error}
-        </div>
-      )}
+      {error && <div className="text-center py-8 text-error">{error}</div>}
 
       {!isLoading && !error && popularChannels.length === 0 && (
         <div className="text-center py-8 text-base-content/70">

--- a/src/pages/chats/public/PublicChat.tsx
+++ b/src/pages/chats/public/PublicChat.tsx
@@ -1,18 +1,18 @@
-import PublicChatHeader from "./PublicChatHeader"
-import ChatContainer from "../components/ChatContainer"
-import {SortedMap} from "@/utils/SortedMap/SortedMap"
-import {shouldHideAuthor} from "@/utils/visibility"
-import {useNavigate, useParams} from "react-router"
-import {comparator} from "../utils/messageGrouping"
-import {useEffect, useState, useRef} from "react"
-import {NDKEvent} from "@nostr-dev-kit/ndk"
-import MessageForm from "../message/MessageForm"
-import {MessageType} from "../message/Message"
-import {Helmet} from "react-helmet"
-import {ndk} from "@/utils/ndk"
 import {CHANNEL_MESSAGE, REACTION_KIND} from "../utils/constants"
 import {usePublicChatsStore} from "@/stores/publicChats"
+import ChatContainer from "../components/ChatContainer"
+import {SortedMap} from "@/utils/SortedMap/SortedMap"
+import {comparator} from "../utils/messageGrouping"
+import {shouldHideAuthor} from "@/utils/visibility"
+import {useNavigate, useParams} from "react-router"
+import PublicChatHeader from "./PublicChatHeader"
+import {useEffect, useState, useRef} from "react"
+import MessageForm from "../message/MessageForm"
+import {MessageType} from "../message/Message"
+import {NDKEvent} from "@nostr-dev-kit/ndk"
 import {useUserStore} from "@/stores/user"
+import {Helmet} from "react-helmet"
+import {ndk} from "@/utils/ndk"
 
 let publicKey = useUserStore.getState().publicKey
 useUserStore.subscribe((state) => (publicKey = state.publicKey))
@@ -35,7 +35,6 @@ const PublicChat = () => {
     if (!id) return
     addOrRefreshChatById(id)
   }, [id, addOrRefreshChatById])
-
 
   // Set up timeout to show "No messages yet" after 2 seconds
   useEffect(() => {
@@ -227,7 +226,7 @@ const PublicChat = () => {
   return (
     <>
       <Helmet>
-        <title>{id && publicChats[id]?.name || "Public Chat"}</title>
+        <title>{(id && publicChats[id]?.name) || "Public Chat"}</title>
       </Helmet>
       <PublicChatHeader channelId={id || ""} />
       <ChatContainer

--- a/src/pages/chats/public/PublicChatCreation.tsx
+++ b/src/pages/chats/public/PublicChatCreation.tsx
@@ -1,13 +1,13 @@
-import {NDKEvent} from "@nostr-dev-kit/ndk"
+import {ChannelMetadata, getChannelsByFollowed} from "../utils/channelMetadata"
+import MinidenticonImg from "@/shared/components/user/MinidenticonImg"
+import {searchChannels} from "../utils/channelSearch"
 import {useState, FormEvent, useEffect} from "react"
+import ProxyImg from "@/shared/components/ProxyImg"
+import PopularChannels from "./PopularChannels"
+import {NDKEvent} from "@nostr-dev-kit/ndk"
+import {useUserStore} from "@/stores/user"
 import {useNavigate} from "react-router"
 import {ndk} from "@/utils/ndk"
-import PopularChannels from "./PopularChannels"
-import {useUserStore} from "@/stores/user"
-import ProxyImg from "@/shared/components/ProxyImg"
-import MinidenticonImg from "@/shared/components/user/MinidenticonImg"
-import { searchChannels } from "../utils/channelSearch"
-import { ChannelMetadata, getChannelsByFollowed } from "../utils/channelMetadata"
 
 let publicKey = useUserStore.getState().publicKey
 useUserStore.subscribe((state) => {
@@ -128,11 +128,18 @@ const PublicChatCreation = () => {
                       square={true}
                     />
                   ) : (
-                    <MinidenticonImg username={metadata.id} className="w-10 h-10 rounded-full" />
+                    <MinidenticonImg
+                      username={metadata.id}
+                      className="w-10 h-10 rounded-full"
+                    />
                   )}
                   <div className="flex flex-col break-words [overflow-wrap:anywhere]">
                     <span className="font-medium line-clamp-1">{metadata.name}</span>
-                    {metadata.about && <span className="text-sm opacity-70 line-clamp-2">{metadata.about}</span>}
+                    {metadata.about && (
+                      <span className="text-sm opacity-70 line-clamp-2">
+                        {metadata.about}
+                      </span>
+                    )}
                   </div>
                 </div>
               </button>

--- a/src/pages/chats/public/PublicChatDetails.tsx
+++ b/src/pages/chats/public/PublicChatDetails.tsx
@@ -1,10 +1,10 @@
-import {useParams, useNavigate} from "react-router"
-import Header from "@/shared/components/header/Header"
-import {RiShareLine, RiChat1Line} from "@remixicon/react"
-import {useEffect, useState} from "react"
 import {fetchChannelMetadata, ChannelMetadata} from "../utils/channelMetadata"
-import ProxyImg from "@/shared/components/ProxyImg"
+import {RiShareLine, RiChat1Line} from "@remixicon/react"
 import {UserRow} from "@/shared/components/user/UserRow"
+import Header from "@/shared/components/header/Header"
+import ProxyImg from "@/shared/components/ProxyImg"
+import {useParams, useNavigate} from "react-router"
+import {useEffect, useState} from "react"
 import {nip19} from "nostr-tools"
 
 const PublicChatDetails = () => {
@@ -32,9 +32,7 @@ const PublicChatDetails = () => {
     <>
       <Header title="Chat Details" showBack />
       <div className="p-4">
-        {!metadata && (
-          <div className="text-center">Chat not found</div>
-        )}
+        {!metadata && <div className="text-center">Chat not found</div>}
         {metadata && (
           <div className="space-y-4">
             <div className="card bg-base-100 shadow-xl">
@@ -70,11 +68,13 @@ const PublicChatDetails = () => {
                   <div>
                     <label className="text-sm text-base-content/70">Channel ID</label>
                     <div className="font-mono text-sm break-all bg-base-200 p-2 rounded">
-                      {id ? nip19.noteEncode(id) : ''}
+                      {id ? nip19.noteEncode(id) : ""}
                     </div>
                   </div>
                   <div>
-                    <label className="text-sm text-base-content/70">Channel ID (Hex)</label>
+                    <label className="text-sm text-base-content/70">
+                      Channel ID (Hex)
+                    </label>
                     <div className="font-mono text-sm break-all bg-base-200 p-2 rounded">
                       {id}
                     </div>
@@ -101,7 +101,10 @@ const PublicChatDetails = () => {
                       <label className="text-sm text-base-content/70">Relays</label>
                       <div className="space-y-1">
                         {metadata.relays.map((relay, index) => (
-                          <div key={index} className="font-mono text-sm break-all bg-base-200 p-2 rounded">
+                          <div
+                            key={index}
+                            className="font-mono text-sm break-all bg-base-200 p-2 rounded"
+                          >
                             {relay}
                           </div>
                         ))}
@@ -117,7 +120,9 @@ const PublicChatDetails = () => {
                   <div>
                     <label className="text-sm text-base-content/70">Created At</label>
                     <div className="font-mono text-sm break-all bg-base-200 p-2 rounded">
-                      {metadata?.createdAt ? new Date(metadata.createdAt * 1000).toLocaleString() : 'Unknown'}
+                      {metadata?.createdAt
+                        ? new Date(metadata.createdAt * 1000).toLocaleString()
+                        : "Unknown"}
                     </div>
                   </div>
                 </div>

--- a/src/pages/chats/public/PublicChatHeader.tsx
+++ b/src/pages/chats/public/PublicChatHeader.tsx
@@ -1,11 +1,11 @@
 import MinidenticonImg from "@/shared/components/user/MinidenticonImg"
-import Dropdown from "@/shared/components/ui/Dropdown"
-import Header from "@/shared/components/header/Header"
-import ProxyImg from "@/shared/components/ProxyImg"
 import {usePublicChatsStore} from "@/stores/publicChats"
 import {RiEarthLine, RiMoreLine} from "@remixicon/react"
-import {useEffect, useState} from "react"
+import Header from "@/shared/components/header/Header"
+import Dropdown from "@/shared/components/ui/Dropdown"
+import ProxyImg from "@/shared/components/ProxyImg"
 import {Link, useNavigate} from "react-router"
+import {useEffect, useState} from "react"
 
 interface PublicChatHeaderProps {
   channelId: string
@@ -17,7 +17,6 @@ const PublicChatHeader = ({channelId}: PublicChatHeaderProps) => {
   const navigate = useNavigate()
   const {publicChats, removePublicChat} = usePublicChatsStore()
   const chat = publicChats[channelId]
-
 
   useEffect(() => {
     // Set a timeout to show the placeholder after 2 seconds if metadata hasn't loaded
@@ -59,9 +58,19 @@ const PublicChatHeader = ({channelId}: PublicChatHeaderProps) => {
   }
 
   return (
-    <Header title={renderTitle()} showBack showNotifications={false} scrollDown={true} slideUp={false} bold={false}>
+    <Header
+      title={renderTitle()}
+      showBack
+      showNotifications={false}
+      scrollDown={true}
+      slideUp={false}
+      bold={false}
+    >
       <div className="flex items-center justify-between w-full">
-        <Link to={`/chats/${channelId}/details`} className="flex items-center gap-2 flex-1">
+        <Link
+          to={`/chats/${channelId}/details`}
+          className="flex items-center gap-2 flex-1"
+        >
           <div className="w-8 h-8 flex items-center justify-center">{renderIcon()}</div>
           <div className="flex flex-col items-start">
             <span className="font-medium flex items-center gap-1">{renderTitle()}</span>

--- a/src/shared/hooks/useFeedEvents.ts
+++ b/src/shared/hooks/useFeedEvents.ts
@@ -171,9 +171,7 @@ export default function useFeedEvents({
       const isMyRecent =
         event.pubkey === myPubKey && event.created_at * 1000 > Date.now() - 10000
       const isNewEvent =
-        initialLoadDoneRef.current &&
-        !isMyRecent &&
-        (!sortLikedPosts || event.kind === 1)
+        initialLoadDoneRef.current && !isMyRecent && (!sortLikedPosts || event.kind === 1)
 
       if (isNewEvent) addNew()
       else addMain()

--- a/tests/utils/performance.ts
+++ b/tests/utils/performance.ts
@@ -56,7 +56,7 @@ export async function measureScrollPerformance(page: Page): Promise<number> {
 export async function getMemoryUsage(page: Page): Promise<number> {
   return await page.evaluate(() => {
     if ("memory" in performance && performance.memory) {
-      const memory = performance.memory as any
+      const memory = performance.memory as unknown as {usedJSHeapSize: number}
       return Math.round(memory.usedJSHeapSize / 1024 / 1024)
     }
     return 0

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,9 +26,6 @@
       "@/*": ["src/*"]
     }
   },
-  "include": [
-    "custom.d.ts",
-    "src"
-  ],
+  "include": ["custom.d.ts", "src"],
   "references": [{"path": "./tsconfig.node.json"}]
 }


### PR DESCRIPTION
## Summary
- fix `.prettierignore` so only the root `public` directory is excluded
- add scripts to check lint, format and types
- run lint, prettier and type checking in CI
- implement `extractMetric` for performance baseline
- avoid `any` cast in memory usage helper
- run prettier across the repo

## Testing
- `yarn lint:check`
- `yarn format:check`
- `yarn typecheck`
- `yarn test` *(fails: connect ECONNREFUSED 127.0.0.1:8080)*

------
https://chatgpt.com/codex/tasks/task_e_687657ce8b7c8326a7b2fd1a53552849