### PR TITLE
Fix post truncation layout

### DIFF
--- a/src/shared/components/HyperText.tsx
+++ b/src/shared/components/HyperText.tsx
@@ -65,9 +65,14 @@ const HyperText = memo(
         let isTruncated = false
         const truncatedChildren = result.reduce(
           (acc: Array<ReactNode | string>, child) => {
+            if (isTruncated) {
+              return acc
+            }
+
             if (typeof child === "string") {
               if (charCount + child.length > truncate) {
                 acc.push(child.substring(0, truncate - charCount))
+                charCount = truncate
                 isTruncated = true
                 return acc
               }


### PR DESCRIPTION
## Summary
- stop processing inline elements once truncation limit is reached to avoid stray links appearing

## Testing
- `yarn test` *(fails: connect ECONNREFUSED 127.0.0.1:8080)*

------
https://chatgpt.com/codex/tasks/task_e_68777d64a9088326958a6487750551e7